### PR TITLE
Docstring examples show output; doctests gate PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,128 @@
+# Contributing to Logjam
+
+## Docstring examples must show their output
+
+Every exported function's docstring carries an `# Example` (or `# Examples`) section, and
+that example **shows its actual output**. An example that shows only how to *call* a
+function documents half the contract; showing the return makes the docstring an oracle —
+a reader can write a unit test against it without running anything, and a reader who does
+run it sees immediately if behavior has drifted.
+
+There are two tiers, chosen by whether the output is deterministic and stable.
+
+### Tier 1 — deterministic → `jldoctest` (CI-enforced)
+
+Pure functions with stable output use a **script-form** `jldoctest` block: the code, a
+`# output` marker, then the expected result.
+
+````julia
+"""
+    ...
+```jldoctest
+k = [8, 8, 10, 8, 9, 8]
+C = [0 3 7 10 6 4; 3 0 4 7 6 7; 7 4 0 3 6 8; 10 7 3 0 7 8; 6 6 6 7 0 2; 4 7 8 8 2 0]
+y, TC, W = ufladd(k, C)
+(y, TC)
+
+# output
+
+([2, 6], 32.0)
+```
+"""
+````
+
+Use the **`# output`** (script) form, not the `julia> ` (REPL) form. The code above
+`# output` is plain, copy-paste-runnable Julia — it runs as a VS Code cell, the workflow
+the course uses — while Documenter still checks the result. Reserve the `julia> ` form for
+the rare case that needs interleaved intermediate checks.
+
+These blocks are executed by `Documenter.doctest` and **gate every pull request** (see
+[Running the doctests](#running-the-doctests)).
+
+### Tier 2 — fragile → runnable block with a captured-output comment
+
+Some functions cannot produce stable, exact output and must **not** be `jldoctest`:
+
+| Fragility | Functions (examples) | Reason |
+|-----------|----------------------|--------|
+| RNG-dependent | `randX`, `ala` | Julia's RNG stream is not stable across versions |
+| Network | `loc2lonlat`, `lonlat2loc` | depend on the Nominatim service / cache |
+| Figures | `makemap`, `plotroads!`, `plotroute!` | return plot objects with unstable `show` |
+| Bulk data | census/CBSA/CSA + FAF5 loaders | large `DataFrame`s; print format changes across DataFrames.jl versions |
+
+These use a plain ` ```julia ` block annotated with a `# =>` comment showing the *stable*
+part of the result — column names, row counts, return shape, or discrete fields — captured
+from a live run:
+
+````julia
+```julia
+df = uscbsa()
+names(df)   # => ["CBSA", "NAME", "LON", "LAT", "POP", "ALAND", "AWATER", "IS_MSA", "CSA", "ISCUS"]
+filter(r -> r.IS_MSA, df)       # => 382 of 918 are Metropolitan Statistical Areas
+```
+````
+
+### Choosing a tier
+
+```
+Is the output deterministic AND stable across platform/version?
+├─ yes → jldoctest  # output      (CI-enforced)
+└─ no  → julia block + # => comment
+         (RNG, network, figures, or a full DataFrame display)
+```
+
+## Output stability rules (for Tier 1)
+
+CI runs on **Linux** (Julia 1.12 and `pre`); development is often on **Windows**. Doctest
+output is compared literally, so it must be identical across both.
+
+- **Algebraic / exact** (`+`, `*`, correctly-rounded `sqrt`, integer results): show
+  verbatim. IEEE 754 guarantees bit-identical results across platforms.
+- **Transcendental / floating-point** (`sin`/`cos`/`atan`-based distances, weighted
+  centroids): **round** in the example — e.g. `round(dgc(...); digits=1)` or
+  `round.(D; digits=1)`. Different libm implementations differ in the last ULP, which
+  would break an exact match.
+- **Discrete** (symbols, small integers, booleans): show verbatim — quantized output is
+  robust to ULP noise (e.g. `aligntext`).
+- **DataFrames**: do not doctest a rendered table (its format changes across DataFrames.jl
+  versions). Doctest a stable projection instead — `names(df)`, `nrow(df)`, a single value.
+
+Prefer a clean one-line final expression (a scalar or a tuple) over a multi-line array
+display where practical; it is easier to read and less brittle.
+
+## Running the doctests
+
+The dedicated docs CI job only runs on release tags, so the doctests are also wired into
+the test suite (`test/test_doctests.jl`) and run on **every PR**. To run them locally:
+
+```julia
+using Pkg; Pkg.test()          # full suite, including the `doctests` testset
+```
+
+or, faster, just the doctests against the docs environment:
+
+```julia
+julia --project=docs -e '
+    using Documenter, Logjam
+    DocMeta.setdocmeta!(Logjam, :DocTestSetup, :(using Logjam); recursive=true)
+    doctest(Logjam; manual=false)'
+```
+
+When output legitimately changes, the failure message prints the actual value — paste it
+into the `# output` block. (`doctest(Logjam; fix=true)` can rewrite outputs automatically,
+but it is finicky when the module loads from a precompiled cache; the paste-from-failure
+path is more reliable.)
+
+## Sourced examples
+
+Where a canonical, citable example exists, prefer it over an ad-hoc one — a reader can then
+verify correctness against the source. The UFL family (`ufladd`, `ufldrop`, `uflxchg`,
+`ufl`, `pmedian`) shares Example 8.8 from Francis, McGinnis & White, *Facility Layout and
+Location* (2nd ed.; Daskin, *Network and Discrete Location*, 1995, Figs. 7.2/7.3/7.5), the
+same example the Matlog originals ship.
+
+## Naming
+
+Follow current Logjam conventions (`k` for fixed cost, `C` for the cost matrix, `W` for the
+allocation matrix, `LON`/`LAT` order). Matlog is a useful reference for algorithm provenance
+and documentation *style*, but its variable names are dated — do not copy them.

--- a/Project.toml
+++ b/Project.toml
@@ -37,6 +37,7 @@ CSV = "0.10"
 CairoMakie = "0.12 - 0.15"
 DataFrames = "1.6 - 1"
 DelaunayTriangulation = "1.1 - 1"
+Documenter = "1"
 GLMakie = "0.10 - 0.13"
 GeoMakie = "0.7 - 0"
 Graphs = "1.9 - 1"
@@ -51,6 +52,7 @@ julia = "1.12"
 
 [extras]
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 GeoMakie = "db073c08-6b98-4ee5-b6a4-5efafb3259c6"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
@@ -62,4 +64,4 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["CairoMakie", "GeoMakie", "LightOSM", "NearestNeighbors", "Random", "SimpleWeightedGraphs", "SparseArrays", "Test"]
+test = ["CairoMakie", "Documenter", "GeoMakie", "LightOSM", "NearestNeighbors", "Random", "SimpleWeightedGraphs", "SparseArrays", "Test"]

--- a/src/datatools.jl
+++ b/src/datatools.jl
@@ -53,8 +53,8 @@ Geographic data derived from [1], population data from [2], and `CBSA` from [3].
 # Example
 ```julia
 df = usplace()
-names(df)                       # LON precedes LAT
-filter(r -> r.ST == :NC, df)    # places in North Carolina
+names(df)   # => ["STFIP", "PLFIP", "NAME", "ST", "LON", "LAT", "POP", "ALAND", "AWATER", "LSAD", "FUNCSTAT", "CBSA", "ISCUS"]  (LON precedes LAT)
+filter(r -> r.ST == :NC, df)    # => 776 places in North Carolina
 ```
 """
 function usplace()
@@ -92,7 +92,8 @@ Area data from [1], population and center of population data from [2], and CBSA 
 # Example
 ```julia
 df = uscounty()
-first(df, 5)                    # LON precedes LAT
+names(df)     # => ["STFIP", "COFIP", "NAME", "ST", "LON", "LAT", "POP", "ALAND", "AWATER", "CBSA"]
+first(df, 5)  # LON precedes LAT
 ```
 """
 function uscounty()
@@ -128,7 +129,8 @@ Area data from [1]. Population and center of population data from [2].
 # Example
 ```julia
 df = uscentract()
-filter(r -> r.ST == :NC, df)    # census tracts in North Carolina (ST is a Symbol)
+names(df)   # => ["STFIP", "COFIP", "TRFIP", "ST", "LON", "LAT", "POP", "ALAND", "AWATER", "ISCUS"]
+filter(r -> r.ST == :NC, df)    # => 2655 census tracts in North Carolina (ST is a Symbol)
 ```
 """
 function uscentract()
@@ -165,6 +167,7 @@ Area data from [1]. Population and center of population data from [2].
 # Example
 ```julia
 df = uscenblkgrp()
+names(df)   # => ["STFIP", "COFIP", "TRFIP", "BGFIP", "LON", "LAT", "POP", "ALAND", "AWATER"]  (no NAME/ST)
 nrow(df)                        # number of block groups
 first(df, 5)                    # LON precedes LAT
 ```
@@ -199,7 +202,8 @@ Geographic data derived from [1]. Population data derived from [2]. `ISCUS` dete
 # Example
 ```julia
 df = uszcta5()
-first(df, 5)                    # LON precedes LAT
+names(df)     # => ["ZCTA5", "LON", "LAT", "POP", "ALAND", "AWATER", "ISCUS"]
+first(df, 5)  # LON precedes LAT
 ```
 """
 function uszcta5()
@@ -228,7 +232,8 @@ All data derived from `uszcta5`.
 # Example
 ```julia
 df = uszcta3()
-first(df, 5)                    # LON precedes LAT
+names(df)     # => ["ZCTA3", "LON", "LAT", "POP", "ALAND", "AWATER", "ISCUS"]
+first(df, 5)  # LON precedes LAT
 ```
 """
 function uszcta3()
@@ -262,7 +267,8 @@ CBSA delineations and classifications from [1]. Geographic and population data f
 # Example
 ```julia
 df = uscbsa()
-filter(r -> r.IS_MSA, df)       # Metropolitan Statistical Areas only (IS_MSA::Bool)
+names(df)   # => ["CBSA", "NAME", "LON", "LAT", "POP", "ALAND", "AWATER", "IS_MSA", "CSA", "ISCUS"]
+filter(r -> r.IS_MSA, df)       # => 382 of 918 are Metropolitan Statistical Areas (IS_MSA::Bool)
 ```
 """
 function uscbsa()
@@ -293,7 +299,8 @@ CSA delineations and classifications from [1]. Geographic and population data fr
 # Example
 ```julia
 df = uscsa()
-first(df, 5)                    # LON precedes LAT; NAME::String
+names(df)     # => ["CSA", "NAME", "LON", "LAT", "POP", "ALAND", "AWATER"]
+first(df, 5)  # LON precedes LAT; NAME::String
 ```
 """
 function uscsa()
@@ -438,7 +445,8 @@ https://geodata.bts.gov/datasets/usdot::freight-analysis-framework-faf5-network-
 # Example
 ```julia
 df = faf5nodes()
-first(df, 5)                    # IDX, LON, LAT, ...
+names(df)     # => ["IDX", "LON", "LAT", "ENTRY_EXIT", "EXIT_NUM", "INTERCHANGE", "FACILITY_TYPE", "FACILITY_NAME", "STATEID", "FAFID"]
+first(df, 5)  # IDX, LON, LAT, ...
 ```
 """
 function faf5nodes()
@@ -488,7 +496,8 @@ https://geodata.bts.gov/datasets/usdot::freight-analysis-framework-faf5-network-
 # Example
 ```julia
 df = faf5links()
-first(df, 5)                    # SRC, DST, DIST, ...
+names(df)     # => ["SRC", "DST", "DIST", "STFIP", "COFIP", "SPEED", "NHS", "SIGN", "NAME", "FCLASS", "URBAN", "AB_SPEED", "BA_SPEED", "AB_TIME", "BA_TIME", "AB_LANES", "BA_LANES", "DIR", "STRAHNET", "NHFN", "TOLL_TYPE", "TOLL_LINK", "BORDER_LINK", "FAFZONE", "STATUS"]
+first(df, 5)  # SRC, DST, DIST, ...
 ```
 """
 function faf5links()
@@ -507,7 +516,7 @@ road network backgrounds.
 # Example
 ```julia
 x, y = faf5interstate()
-length(x)                       # NaN-separated interstate polylines
+length(x), length(x) == length(y)   # => (246969, true)  NaN-separated interstate polylines
 # Plot as a road-network background (requires a Makie axis `ax`):
 # lines!(ax, x, y, color=(:steelblue, 0.3), linewidth=0.5)
 ```

--- a/src/datatools.jl
+++ b/src/datatools.jl
@@ -326,10 +326,15 @@ Valid two-character symbols of the state or territory are
 $(join(sort(collect(keys(state_fips))), ", "))
 
 # Examples
-```julia
-st2fips(:NC)          # => 37
-st2fips.([:NC, :NY])  # => [37, 36]
+```jldoctest
+st2fips(:NC)
+
+# output
+
+37
 ```
+
+Broadcasts over a collection: `st2fips.([:NC, :NY])` returns `[37, 36]`.
 """
 function st2fips(state::Symbol)
     if state in keys(state_fips)
@@ -360,11 +365,15 @@ Valid FIPS codes are: $(join(sort(collect(keys(fips_state))), ", "))
 - `ArgumentError` if the FIPS code is not valid.
 
 # Examples
-```julia
-fips2st(37)      # => :NC
-fips2st(36)      # => :NY
-fips2st.(37:39)  # => [:NC, :ND, :OH]
+```jldoctest
+fips2st(37)
+
+# output
+
+:NC
 ```
+
+Broadcasts over a range: `fips2st.(37:39)` returns `[:NC, :ND, :OH]`.
 """
 function fips2st(fips::Integer)
     if fips in keys(fips_state)
@@ -578,18 +587,26 @@ With `str=true`, returns the formatted table as a string (separator lines stripp
 instead of printing. Default behavior prints to stdout and returns `nothing`.
 
 # Examples
-```julia
-julia> prt([1000 0.1234; 2000 0.5678])
-       1        2
-────────────────────
-  1  1,000   0.1234
-  2  2,000   0.5678
+```jldoctest
+prt([1000 0.1234; 2000 0.5678])
 
-julia> prt([1 2; 3 4]; rows=["a","b"], cols=["X","Y"], row_title="ID")
-  ID    X    Y
-──────────────
-   a    1    2
-   b    3    4
+# output
+
+       1       2
+────────────────
+1  1,000  0.1234
+2  2,000  0.5678
+```
+
+```jldoctest
+prt([1 2; 3 4]; rows=["a", "b"], cols=["X", "Y"], row_title="ID")
+
+# output
+
+ID  X  Y
+────────
+ a  1  2
+ b  3  4
 ```
 """
 function prt(X::AbstractMatrix; rows=1:size(X, 1), cols=1:size(X, 2),
@@ -828,10 +845,19 @@ can violate the associated constraint by a large amount.
 - `atol`: Tolerance for snapping (default: `1e-8`).
 
 # Example
-```julia
-snapvals([2.9999999997, 1e-12, 0.5])   # => [3.0, 0.0, 0.5]
-snapvals([1.0, 2.0, 3.0, 4.0], 2, 2)   # => [1.0 3.0; 2.0 4.0]
+```jldoctest
+snapvals([2.9999999997, 1e-12, 0.5])
+
+# output
+
+3-element Vector{Float64}:
+ 3.0
+ 0.0
+ 0.5
 ```
+
+With dimensions, the result is reshaped: `snapvals([1.0, 2.0, 3.0, 4.0], 2, 2)` returns
+`[1.0 3.0; 2.0 4.0]`.
 """
 function snapvals(x; atol::Real=1e-8)
     arr = Array(x)
@@ -867,19 +893,24 @@ Determines whether a given point lies within a specified bounding box.
   - `false` otherwise.
 
 # Example
-```julia
+```jldoctest
 bbox = ((0, 10), (0, 15))
-isptinbbox((5, 10), bbox)   # => true   (inside)
-isptinbbox((15, 10), bbox)  # => false  (outside)
+(isptinbbox((5, 10), bbox), isptinbbox((15, 10), bbox))   # inside, outside
 
-# DataFrame filter idiom (primary; matches course usage): keep the rows whose
-# (LON, LAT) falls inside a bounding box.
+# output
+
+(true, false)
+```
+
+DataFrame filter idiom (primary; matches course usage) — keep the rows whose `(LON, LAT)`
+falls inside a bounding box, and the bare-matrix broadcast over an N×2 coordinate matrix:
+
+```julia
 using Logjam, DataFrames
 df = usplace()
 ncbox = ((-84.5, -75.0), (33.5, 36.7))          # ((xmin, xmax), (ymin, ymax))
 filter(r -> isptinbbox((r.LON, r.LAT), ncbox), df)
 
-# Bare-matrix broadcast idiom over the rows of an N×2 coordinate matrix:
 X = [-80.0 35.5; -78.0 40.0]
 isptinbbox.(eachrow(X), Ref(ncbox))   # => Bool[1, 0]
 ```
@@ -912,16 +943,24 @@ vector of coordinates per hub, enabling per-hub formatting (e.g., different colo
   `X[i]` and `Y[i]` contain NaN-separated coordinates for hub i's allocation lines.
 
 # Example
-```julia
-k = [100.0, 100.0, 150.0]
-C = [0 3 7 10; 3 0 4 8; 7 4 0 5]
-y, TC, W = ufl(k, C; verbose=false)
+Each hub's segments are `[hub, spoke, NaN, hub, spoke, NaN, …]`; an unused hub yields an
+empty vector.
 
-hubs = [-80.0 35.0; -78.0 36.0; -79.0 35.5]
-spokes = [-80.5 35.2; -78.5 35.8; -79.2 36.1; -78.0 35.0]
-
+```jldoctest
+W = [1.0 0.0; 0.0 1.0]          # hub 1 serves spoke 1; hub 2 serves spoke 2
+hubs = [0.0 0.0; 1.0 1.0]
+spokes = [0.5 0.5; 2.0 2.0]
 X, Y = alloclines(W, hubs, spokes)
+X
+
+# output
+
+2-element Vector{Vector{Float64}}:
+ [0.0, 0.5, NaN]
+ [1.0, 2.0, NaN]
 ```
+
+In practice `W` comes from an allocation solver, e.g. `_, _, W = ufl(k, C; verbose=false)`.
 """
 function alloclines(W::AbstractMatrix, hub_xy::AbstractMatrix, spoke_xy::AbstractMatrix;
                     tol::Real=sqrt(eps(Float64)))

--- a/src/disttools.jl
+++ b/src/disttools.jl
@@ -11,15 +11,21 @@ between two points specified by longitude-latitude coordinates.
 # Arguments
 - `xy₁`: Tuple or vector of (longitude, latitude) for the first point.
 - `xy₂`: Tuple or vector of (longitude, latitude) for the second point.
-- `unit`: Distance unit, either `:mi` (miles, default) or `:km` (kilometers).
+- `unit`: Distance unit — `:mi` (miles, default), `:km` (kilometers), or `:rad` (radians of arc).
 
 # Returns
 - Great circle distance in the specified unit.
 
 # Example
-```julia
-# Distance from Raleigh to Charlotte
-dgc((-78.6382, 35.7796), (-80.8431, 35.2271))  # ≈ 130 miles
+Distance from Raleigh to Charlotte (rounded for a stable, cross-platform doctest — the
+raw `Float64` carries full precision).
+
+```jldoctest
+round(dgc((-78.6382, 35.7796), (-80.8431, 35.2271)); digits=1)
+
+# output
+
+129.8
 ```
 """
 function dgc(xy1, xy2; unit=:mi)
@@ -53,9 +59,12 @@ Calculate rectilinear (Manhattan, L₁) distance between two points.
 - Sum of absolute differences: Σ|x₁ᵢ - x₂ᵢ|.
 
 # Example
-```julia
-d1([0, 0], [3, 4])  # Returns 7.0
-d1([1, 2, 3], [4, 6, 2])  # Returns 8.0
+```jldoctest
+(d1([0, 0], [3, 4]), d1([1, 2, 3], [4, 6, 2]))
+
+# output
+
+(7.0, 8.0)
 ```
 """
 d1(x₁, x₂) = float(sum(abs.(x₁ .- x₂)))
@@ -73,9 +82,12 @@ Calculate Euclidean (L₂) distance between two points.
 - Euclidean distance: √(Σ(x₁ᵢ - x₂ᵢ)²).
 
 # Example
-```julia
-d2([0, 0], [3, 4])  # Returns 5.0
-d2([1, 2, 3], [4, 6, 2])  # Returns ≈5.0990
+```jldoctest
+d2([0, 0], [3, 4])
+
+# output
+
+5.0
 ```
 """
 d2(x₁, x₂) = sqrt(sum((x₁ .- x₂).^2))
@@ -116,26 +128,37 @@ The symbol forms ``:mi``/``:km`` return the great-circle distance on the sphere 
 named unit, and ``:rad`` returns radians of arc.
 
 # Examples
-```julia
-# Euclidean (default)
+Euclidean (default):
+
+```jldoctest
 X1 = [0.0 0.0; 10.0 0.0]
 X2 = [5.0 0.0; 5.0 5.0]
-D = dists(X1, X2)  # 2×2 matrix
+dists(X1, X2)
 
-# Manhattan distance
-D = dists(X1, X2, 1)
+# output
 
-# General lₚ and Chebychev (l∞)
-D = dists(X1, X2, 3.0)   # (Σ|Δ|³)^(1/3)
-D = dists(X1, X2, Inf)   # maximum(abs, Δ)
-
-# Great circle distance (lon-lat coordinates)
-cities = [-78.64 35.78; -122.42 37.77]  # Raleigh, SF
-dc = [-77.04 38.91]                      # Washington DC
-D = dists(cities, dc, :mi)               # Statute miles
-D = dists(cities, dc, :km)               # Kilometers
-D = dists(cities, dc, :rad)              # Radians of arc
+2×2 Matrix{Float64}:
+ 5.0  7.07107
+ 5.0  7.07107
 ```
+
+Great-circle distance from lon-lat coordinates (rounded for a stable doctest):
+
+```jldoctest
+cities = [-78.64 35.78; -122.42 37.77]   # Raleigh, San Francisco
+dc = [-77.04 38.91]                       # Washington, DC
+round.(dists(cities, dc, :mi); digits=1)  # statute miles
+
+# output
+
+2×1 Matrix{Float64}:
+  233.4
+ 2434.8
+```
+
+Other metrics follow the same call form: `dists(X1, X2, 1)` (Manhattan), `dists(X1, X2,
+3.0)` (general lₚ), `dists(X1, X2, Inf)` (Chebychev), and `:km`/`:rad` for great-circle in
+kilometers or radians.
 
 See also: [`dgc`](@ref), [`d1`](@ref), [`d2`](@ref)
 """
@@ -226,12 +249,20 @@ caller. Degenerate ``a_j = 0`` gives floor ``0``, so ``D^{aa}_{ij} = d_{gc}``.
 - `D`: n×m matrix where `D[i,j] = max(dgc(X[i,:], Xa[j,:]; unit), (2/3)√(a[j]/π))`.
 
 # Example
-```julia
-# Two facilities, two demand points (LON, LAT); demand areas in mi²
+Two facilities, two demand points (LON, LAT); demand areas in mi² (rounded for a stable
+doctest):
+
+```jldoctest
 X  = [-78.64 35.78; -80.84 35.23]     # Raleigh, Charlotte
 Xa = [-79.79 36.07; -77.94 34.23]     # Greensboro, Wilmington
-a  = [0.0, 500.0]                      # Wilmington floored by a 500 mi² disk
-D  = dgca(X, Xa, a)                    # 2×2 raw distances (no circuity)
+a  = [0.0, 500.0]                     # Wilmington floored by a 500 mi² disk
+round.(dgca(X, Xa, a); digits=1)      # 2×2 raw distances (no circuity)
+
+# output
+
+2×2 Matrix{Float64}:
+ 67.4  114.2
+ 82.7  178.6
 ```
 
 See also: [`dgc`](@ref), [`dists`](@ref)

--- a/src/geocode.jl
+++ b/src/geocode.jl
@@ -481,9 +481,10 @@ are UPPERCASE (`LON`, `LAT`); metadata fields are lowercase.
 
 # Examples
 ```julia
-loc2lonlat("123 Main St, Raleigh, NC 27601")
-loc2lonlat("Raleigh", state=:NC)
-loc2lonlat("27601")
+loc2lonlat("Raleigh", state=:NC)   # => (LON, LAT, source="PLACE", uncert, status="OK")
+loc2lonlat("27601")                # => (LON, LAT, source="POSTALCODE", uncert, status="OK")
+loc2lonlat("123 Main St, Raleigh, NC 27601")  # ADDRESS tier via Nominatim (needs HTTP+JSON3;
+                                              # falls back to PLACE/POSTALCODE offline)
 ```
 """
 function loc2lonlat(s::AbstractString; state=nothing, country::Symbol=:US,
@@ -535,6 +536,7 @@ Returns a DataFrame with LON, LAT, GC_SOURCE, GC_UNCERT, GC_STATUS columns.
 # Examples
 ```julia
 loc2lonlat(["Raleigh", "Durham", "Chapel Hill"], state=:NC)
+# => DataFrame with columns INPUT, LON, LAT, GC_SOURCE, GC_UNCERT, GC_STATUS
 loc2lonlat(["27601", "27708", "27514"])
 ```
 """
@@ -586,7 +588,7 @@ Returns the input DataFrame with LON, LAT, GC_SOURCE, GC_UNCERT, GC_STATUS appen
 # Examples
 ```julia
 df = DataFrame(CITY=["Raleigh", "Durham"], STATE=[:NC, :NC])
-loc2lonlat(df)
+loc2lonlat(df)   # => input df with LON, LAT, GC_SOURCE, GC_UNCERT, GC_STATUS appended
 
 df2 = DataFrame(addr=["123 Main St"], town=["Raleigh"], st=["NC"])
 loc2lonlat(df2; street=:addr, city=:town, state=:st)
@@ -665,6 +667,7 @@ Geographic fields are UPPERCASE (`NAME`, `ST`; `ST isa Symbol`); metadata lowerc
 ```julia
 cities = usplace()
 lonlat2loc(-78.6382, 35.7796, cities)
+# => (NAME="Raleigh", ST=:NC, dist, bearing, dir, desc="in Raleigh, NC")
 ```
 """
 function lonlat2loc(lon::Real, lat::Real, df::DataFrame; threshold=nothing)
@@ -682,6 +685,7 @@ Returns DataFrame with columns: idx, NAME, ST, dist, bearing, dir, desc (`ST isa
 ```julia
 cities = usplace()
 lonlat2loc([-78.6382, -80.8431], [35.7796, 35.2271], cities)
+# => DataFrame with columns idx, NAME, ST, dist, bearing, dir, desc
 ```
 """
 function lonlat2loc(x::AbstractVector{<:Real}, y::AbstractVector{<:Real}, df::DataFrame; threshold=nothing)
@@ -704,6 +708,7 @@ Geographic fields are UPPERCASE (`NAME`, `ST`; `ST isa Symbol`); metadata lowerc
 ```julia
 cities = usplace()
 lonlat2loc([-78.6382, 35.7796], cities)
+# => (NAME="Raleigh", ST=:NC, dist, bearing, dir, desc="in Raleigh, NC")
 ```
 """
 function lonlat2loc(xy::AbstractVector, df::DataFrame; threshold=nothing)

--- a/src/loctools.jl
+++ b/src/loctools.jl
@@ -485,12 +485,16 @@ distance ``d`` defaults to the great-circle distance ``d_{gc}`` (`dist=:mi`). Wi
   matrix `W` where `W[i,j]` is the weight facility `i` serves from demand point `j`.
 
 # Example
+Locate two facilities to serve four North Carolina cities. The `locate` step calls a
+continuous optimizer and the orphan rule draws from the RNG, so `TC` is shown rounded and
+may vary slightly across Optim/Julia versions.
+
 ```julia
-# Locate two facilities to serve four North Carolina cities (LON, LAT; population weights)
 P  = [-78.64 35.78; -80.84 35.23; -79.79 36.07; -77.94 34.23]  # Raleigh, Charlotte, Greensboro, Wilmington
 w  = [469.0, 897.0, 299.0, 123.0]
 X0 = [-78.6 35.8; -80.0 35.5]
 X, TC, W = ala(X0, w, P)          # dist=:mi great-circle minisum
+round(TC; digits=1)               # => 34194.6 (great-circle miles)
 ```
 
 # References
@@ -537,9 +541,15 @@ Useful for generating random facility locations for optimization problems.
 - n×d matrix of random points, uniformly distributed within min/max of each dimension.
 
 # Example
+`randX` draws from the RNG, so the coordinates vary run to run (and the exact stream is not
+stable across Julia versions); only the shape is fixed. Seed for reproducibility within a
+session.
+
 ```julia
+using Random; Random.seed!(1)
 P = [0 0; 2 0; 2 3]
-X = randX(P, 5)  # 5 random points in [0,2] × [0,3]
+X = randX(P, 5)      # 5 random points in [0,2] × [0,3]
+size(X)              # => (5, 2)
 ```
 """
 function randX(P::AbstractMatrix, n::Int=1)
@@ -588,9 +598,23 @@ down-weighted in the longitude average. Domain: ``\\sum_i w_i > 0`` and
   composes directly with `combine(groupby(...), ... => wcentroid => [:LON, :LAT])`.
 
 # Example
+Population-weighted centroid of four NC cities (rounded for a stable, cross-platform
+doctest — the raw `Float64`s carry full precision):
+
+```jldoctest
+r = wcentroid([-78.64, -80.84, -79.79, -77.94], [35.78, 35.23, 36.07, 34.23], [469.0, 897.0, 299.0, 123.0])
+round.((r.LON, r.LAT); digits=4)
+
+# output
+
+(-79.8886, 35.4459)
+```
+
+Because it returns a `(LON, LAT)` NamedTuple, it composes directly with `combine` for a
+per-group weighted centroid:
+
 ```julia
 using DataFrames
-# Two clusters keyed by :k; weighted (population) centroid per group
 df = DataFrame(
     k   = [:A, :A, :B, :B],
     LON = [-78.64, -80.84, -79.79, -77.94],
@@ -598,7 +622,6 @@ df = DataFrame(
     POP = [469.0, 897.0, 299.0, 123.0],
 )
 combine(groupby(df, :k), [:LON, :LAT, :POP] => wcentroid => [:LON, :LAT])
-# one row per group with its cos-lat-corrected weighted centroid
 ```
 
 See also: [`ala`](@ref), [`randX`](@ref)

--- a/src/loctools.jl
+++ b/src/loctools.jl
@@ -15,28 +15,46 @@ end
 
 Greedy ADD construction heuristic for uncapacitated facility location.
 
-Iteratively adds facilities that provide the greatest cost reduction until no
-improvement is possible or p facilities are selected.
+Iteratively opens the facility giving the greatest cost reduction until no improvement
+is possible (or `p` facilities are open).
 
 # Arguments
-- `k`: Fixed costs. Scalar (same cost for all) or vector (one per site).
-- `C`: n×m cost matrix where C[i,j] is cost of serving customer j from facility i.
-- `y`: Initial facility set (default: empty, start from scratch).
-- `p`: Maximum facilities to select (default: nothing, no limit).
+- `k`: Fixed cost. Scalar (same cost at every site) or length-`n` vector, `k[i]` = cost
+  of opening a facility at candidate site `i`.
+- `C`: `n`×`m` variable-cost matrix over `n` candidate sites and `m` customers; `C[i,j]`
+  = cost of serving customer `j` from site `i`.
+- `y`: initial set of open sites (default: empty — start from scratch).
+- `p`: cap on the number of open facilities (default: `nothing`, no cap).
 
 # Returns
-- `(y, TC, W)`: Selected facility indices, total cost, and n×m sparse allocation matrix
-  where W[i,j]=1 if facility i serves customer j.
+- `(y, TC, W)`: open-facility site indices; total cost `TC = sum(k[y]) + sum(C[allocated])`;
+  and the `n`×`m` sparse allocation matrix `W`, `W[i,j] = 1` if customer `j` is served by
+  facility `i`.
 
 # Example
-```julia
-k = [10, 10, 10]
-C = [2 5 4; 4 1 3; 5 4 2]
+Example 8.8 in Francis, *Facility Layout and Location*, 2nd ed. (Daskin, *Network and
+Discrete Location*, 1995, Fig. 7.2).
+
+```jldoctest
+k = [8, 8, 10, 8, 9, 8]
+C = [ 0  3  7 10  6  4
+      3  0  4  7  6  7
+      7  4  0  3  6  8
+     10  7  3  0  7  8
+      6  6  6  7  0  2
+      4  7  8  8  2  0]
 y, TC, W = ufladd(k, C)
+(y, TC)
+
+# output
+
+([2, 6], 32.0)
 ```
 
 # References
-- M.G. Kay, *Facility Location* (course notes), NC State University
+- R.L. Francis, L.F. McGinnis, J.A. White, *Facility Layout and Location: An Analytical
+  Approach*, 2nd ed., Ex. 8.8; M.S. Daskin, *Network and Discrete Location*, 1995,
+  Fig. 7.2. Ported from Matlog `ufladd`.
 """
 function ufladd(k, C; y = Int[], p::Union{Int, Nothing} = nothing)
     if k isa Number
@@ -68,28 +86,46 @@ end
 
 Greedy DROP construction heuristic for uncapacitated facility location.
 
-Starts with all facilities open and iteratively drops the one providing the
-greatest cost reduction until no improvement or p facilities remain.
+Starts with every facility open and iteratively closes the one giving the greatest cost
+reduction until no improvement is possible (or `p` remain).
 
 # Arguments
-- `k`: Fixed costs. Scalar (same cost for all) or vector (one per site).
-- `C`: n×m cost matrix where C[i,j] is cost of serving customer j from facility i.
-- `y`: Initial facility set (default: all facilities).
-- `p`: Target number of facilities (default: nothing, drop until no improvement).
+- `k`: Fixed cost. Scalar (same cost at every site) or length-`n` vector, `k[i]` = cost
+  of opening a facility at candidate site `i`.
+- `C`: `n`×`m` variable-cost matrix over `n` candidate sites and `m` customers; `C[i,j]`
+  = cost of serving customer `j` from site `i`.
+- `y`: initial set of open sites (default: all sites open).
+- `p`: target number of open facilities (default: `nothing`, drop until no improvement).
 
 # Returns
-- `(y, TC, W)`: Selected facility indices, total cost, and n×m sparse allocation matrix
-  where W[i,j]=1 if facility i serves customer j.
+- `(y, TC, W)`: open-facility site indices; total cost `TC = sum(k[y]) + sum(C[allocated])`;
+  and the `n`×`m` sparse allocation matrix `W`, `W[i,j] = 1` if customer `j` is served by
+  facility `i`.
 
 # Example
-```julia
-k = [10, 10, 10]
-C = [2 5 4; 4 1 3; 5 4 2]
+Example 8.8 in Francis, *Facility Layout and Location*, 2nd ed. (Daskin, *Network and
+Discrete Location*, 1995, Fig. 7.3). DROP stops at a different local optimum than ADD.
+
+```jldoctest
+k = [8, 8, 10, 8, 9, 8]
+C = [ 0  3  7 10  6  4
+      3  0  4  7  6  7
+      7  4  0  3  6  8
+     10  7  3  0  7  8
+      6  6  6  7  0  2
+      4  7  8  8  2  0]
 y, TC, W = ufldrop(k, C)
+(y, TC)
+
+# output
+
+([2, 4, 6], 32.0)
 ```
 
 # References
-- M.G. Kay, *Facility Location* (course notes), NC State University
+- R.L. Francis, L.F. McGinnis, J.A. White, *Facility Layout and Location: An Analytical
+  Approach*, 2nd ed., Ex. 8.8; M.S. Daskin, *Network and Discrete Location*, 1995,
+  Fig. 7.3. Ported from Matlog `ufldrop`.
 """
 function ufldrop(k, C; y = nothing, p::Union{Int, Nothing} = nothing)
     if k isa Number
@@ -123,27 +159,46 @@ end
 
 Pairwise EXCHANGE improvement heuristic for uncapacitated facility location.
 
-Performs steepest descent pairwise swaps (close one facility, open another)
-until local optimum is reached.
+Steepest-descent swaps (close one open facility, open one closed) from a starting set `y`
+until a local optimum is reached. The swap preserves the number of open facilities, so
+`y` sets the cardinality.
 
 # Arguments
-- `k`: Fixed costs. Scalar (same cost for all) or vector (one per site).
-- `C`: n×m cost matrix where C[i,j] is cost of serving customer j from facility i.
-- `y`: Initial facility set.
+- `k`: Fixed cost. Scalar (same cost at every site) or length-`n` vector (see [`ufladd`](@ref)).
+- `C`: `n`×`m` variable-cost matrix over `n` candidate sites and `m` customers; `C[i,j]`
+  = cost of serving customer `j` from site `i`.
+- `y`: starting set of open sites (required — exchange improves *this* set).
 
 # Returns
-- `(y, TC, W)`: Improved facility indices, total cost, and n×m sparse allocation matrix
-  where W[i,j]=1 if facility i serves customer j.
+- `(y, TC, W)`: improved open-facility site indices; total cost
+  `TC = sum(k[y]) + sum(C[allocated])`; and the `n`×`m` sparse allocation matrix `W`,
+  `W[i,j] = 1` if customer `j` is served by facility `i`.
 
 # Example
-```julia
-k = [10, 10, 10]
-C = [2 5 4; 4 1 3; 5 4 2]
-y, TC, W = uflxchg(k, C, [1, 3])
+Improve the ADD solution to Example 8.8 (Francis, 2nd ed.; Daskin, Fig. 7.5): the swap
+takes the starting set `[2, 6]` (TC 32.0) to `[3, 6]` (TC 31.0).
+
+```jldoctest
+k = [8, 8, 10, 8, 9, 8]
+C = [ 0  3  7 10  6  4
+      3  0  4  7  6  7
+      7  4  0  3  6  8
+     10  7  3  0  7  8
+      6  6  6  7  0  2
+      4  7  8  8  2  0]
+y0, _, _ = ufladd(k, C)          # ADD gives the starting set
+y, TC, W = uflxchg(k, C, y0)
+(y0, y, TC)
+
+# output
+
+([2, 6], [3, 6], 31.0)
 ```
 
 # References
-- M.G. Kay, *Facility Location* (course notes), NC State University
+- R.L. Francis, L.F. McGinnis, J.A. White, *Facility Layout and Location: An Analytical
+  Approach*, 2nd ed., Ex. 8.8; M.S. Daskin, *Network and Discrete Location*, 1995,
+  Fig. 7.5. Ported from Matlog `uflxchg`.
 """
 function uflxchg(k, C, y::Vector{Int})
     if k isa Number
@@ -191,29 +246,47 @@ end
 """
     ufl(k, C; verbose=true) -> (Vector{Int}, Float64, SparseMatrixCSC)
 
-Hybrid UFL heuristic combining ADD, DROP, and EXCHANGE procedures.
+Hybrid UFL heuristic combining ADD, EXCHANGE, and DROP.
 
-Iterates through ADD → EXCHANGE → (ADD vs DROP, take best) until no improvement.
-Typically produces high-quality solutions for uncapacitated facility location problems.
+Iterates ADD → EXCHANGE → (ADD vs DROP, take best) until no improvement. Typically finds
+a better solution than any single procedure alone. With the default `verbose=true`, prints
+the per-step `Add`/`Xchg`/`Drop` cost trace.
 
 # Arguments
-- `k`: Fixed costs. Scalar (same cost for all) or vector (one per site).
-- `C`: n×m cost matrix where C[i,j] is cost of serving customer j from facility i.
-- `verbose`: Print iteration costs (default: true).
+- `k`: Fixed cost. Scalar (same cost at every site) or length-`n` vector (see [`ufladd`](@ref)).
+- `C`: `n`×`m` variable-cost matrix over `n` candidate sites and `m` customers; `C[i,j]`
+  = cost of serving customer `j` from site `i`.
+- `verbose`: print the per-step cost trace (default: `true`).
 
 # Returns
-- `(y, TC, W)`: Best facility indices, total cost, and n×m sparse allocation matrix
-  where W[i,j]=1 if facility i serves customer j.
+- `(y, TC, W)`: best open-facility site indices found; total cost
+  `TC = sum(k[y]) + sum(C[allocated])`; and the `n`×`m` sparse allocation matrix `W`,
+  `W[i,j] = 1` if customer `j` is served by facility `i`.
 
 # Example
-```julia
-k = [10, 10, 15]
-C = [0 3 7; 3 0 4; 7 4 0]
-y, TC, W = ufl(k, C)  # Prints: Add: 17.0, Xchg: 17.0 → y=[2], TC=17.0
+Example 8.8 in Francis, *Facility Layout and Location*, 2nd ed. The hybrid improves on ADD
+(32.0) and DROP (32.0) alone.
+
+```jldoctest
+k = [8, 8, 10, 8, 9, 8]
+C = [ 0  3  7 10  6  4
+      3  0  4  7  6  7
+      7  4  0  3  6  8
+     10  7  3  0  7  8
+      6  6  6  7  0  2
+      4  7  8  8  2  0]
+y, TC, W = ufl(k, C; verbose=false)
+(y, TC)
+
+# output
+
+([3, 6], 31.0)
 ```
 
 # References
-- M.G. Kay, *Facility Location* (course notes), NC State University
+- R.L. Francis, L.F. McGinnis, J.A. White, *Facility Layout and Location: An Analytical
+  Approach*, 2nd ed., Ex. 8.8; M.S. Daskin, *Network and Discrete Location*, 1995.
+  Ported from Matlog `ufl`.
 """
 function ufl(k, C; verbose = true)
     y′, TC′, _ = ufladd(k, C)
@@ -244,28 +317,42 @@ end
 """
     pmedian(p, C; verbose=true) -> (Vector{Int}, Float64, SparseMatrixCSC)
 
-p-median facility location (fixed number of facilities, no fixed costs).
-
-Selects exactly p facilities to minimize total transportation cost. Uses ufladd
-with k=0 to select p facilities, then uflxchg to improve the solution.
+p-median facility location: open exactly `p` facilities (no fixed costs) to minimize total
+assignment cost. Uses [`ufladd`](@ref) with `k=0` to select `p`, then [`uflxchg`](@ref) to
+improve.
 
 # Arguments
-- `p`: Number of facilities to select.
-- `C`: n×m cost matrix where C[i,j] is cost of serving customer j from facility i.
-- `verbose`: Print iteration costs (default: true).
+- `p`: number of facilities to open.
+- `C`: `n`×`m` variable-cost matrix over `n` candidate sites and `m` customers; `C[i,j]`
+  = cost of serving customer `j` from site `i`.
+- `verbose`: print the selection trace (default: `true`).
 
 # Returns
-- `(y, TC, W)`: Selected facility indices, total cost, and n×m sparse allocation matrix
-  where W[i,j]=1 if facility i serves customer j.
+- `(y, TC, W)`: the `p` open-facility site indices; total cost `TC = sum(C[allocated])`
+  (transport only, no fixed costs); and the `n`×`m` sparse allocation matrix `W`,
+  `W[i,j] = 1` if customer `j` is served by facility `i`.
 
 # Example
-```julia
-C = [0 3 7; 3 0 4; 7 4 0]
+Same cost matrix as Example 8.8 (Francis, 2nd ed.), with fixed costs dropped.
+
+```jldoctest
+C = [ 0  3  7 10  6  4
+      3  0  4  7  6  7
+      7  4  0  3  6  8
+     10  7  3  0  7  8
+      6  6  6  7  0  2
+      4  7  8  8  2  0]
 y, TC, W = pmedian(2, C; verbose=false)
+(y, TC)
+
+# output
+
+([6, 3], 13.0)
 ```
 
 # References
-- M.G. Kay, *Facility Location* (course notes), NC State University
+- R.L. Francis, L.F. McGinnis, J.A. White, *Facility Layout and Location: An Analytical
+  Approach*, 2nd ed., Ex. 8.8 (cost matrix). Ported from Matlog `pmedian`.
 """
 function pmedian(p, C; verbose = true)
     1 <= p <= size(C, 1) || error("p must be between 1 and $(size(C, 1))")

--- a/src/maptools.jl
+++ b/src/maptools.jl
@@ -146,7 +146,7 @@ Interstate roads (if used) are derived from FAF5: https://geodata.bts.gov/datase
 # Examples
 ```julia-repl
 # Create a world map using CairoMakie
-fig, ax = makemap()
+fig, ax = makemap()          # => (Figure, GeoAxis)
 
 # Create a U.S. map
 fig, ax = makemap(region=:US)

--- a/src/maptools.jl
+++ b/src/maptools.jl
@@ -7,16 +7,33 @@ A constant defining the geographical limits for a world map projection.
 
 - The first tuple specifies the longitude limits in degrees: `(-180, 180)`.
 - The second tuple specifies the latitude limits in degrees: `(-75, 75)`.
+
+```jldoctest
+WORLD_LIMITS
+
+# output
+
+((-180, 180), (-75, 75))
+```
 """
 const WORLD_LIMITS = ((-180, 180), (-75, 75))
 
 """
     US_LIMITS
 
-A constant defining the geographical limits for a map projection of the contiguous United States.
+A constant defining the geographical limits for a map projection of the United States,
+including Alaska and Hawaii (the longitude range reaches to `-180` to cover the Aleutians).
 
 - The first tuple specifies the longitude limits in degrees: `(-180, -65)`.
 - The second tuple specifies the latitude limits in degrees: `(15, 72)`.
+
+```jldoctest
+US_LIMITS
+
+# output
+
+((-180, -65), (15, 72))
+```
 """
 const US_LIMITS = ((-180, -65), (15, 72))
 
@@ -27,6 +44,14 @@ A constant defining the geographical limits for a map projection of the contiguo
 
 - The first tuple specifies the longitude limits in degrees: `(-125, -65)`.
 - The second tuple specifies the latitude limits in degrees: `(24, 50)`.
+
+```jldoctest
+CUS_LIMITS
+
+# output
+
+((-125, -65), (24, 50))
+```
 """
 const CUS_LIMITS = ((-125, -65), (24, 50))
 
@@ -171,14 +196,27 @@ This function attempts to calculate the best alignment and offset positions for 
 - **Three or More Points**: For three or more points, the function uses Delaunay triangulation to determine the optimal alignment by analyzing the angles and distances between adjacent points. It ensures that labels do not overlap and are well-positioned relative to each other.
 
 # Example
-```julia-repl
-# Example: Cities in North Carolina with populaions over 100,000
+A single point gets the default lower-left placement; multiple points return per-point
+alignment/offset vectors (the output is discrete symbols and integer offsets):
+
+```jldoctest
+aligntext(0.0, 0.0)
+
+# output
+
+(:align => (:left, :bottom), :offset => (1, 1))
+```
+
+In a plot, splat the result straight into `text!` — for example, labeling the NC cities
+over 100,000 population:
+
+```julia
 using CairoMakie, GeoMakie, DataFrames
 df = filter(r -> (r.STFIP == st2fips(:NC)) && (r.POP > 100_000), usplace())
 x, y, name = df.LON, df.LAT, df.NAME
 fig, ax = makemap(x, y)
 scatter!(ax, x, y)
-text!(ax, x, y, text=name; aligntext(x, y)...)  # Note ";" and "..." for splatting
+text!(ax, x, y, text=name; aligntext(x, y)...)  # note ";" and "..." for splatting
 display(fig)
 ```
 """
@@ -314,15 +352,28 @@ Calculates the bounding box for a set of geographic coordinates, with optional e
 - Throws `ArgumentError` if `x` or `y` contains no non-`NaN` values.
 
 # Example
-```julia
+Tight bounding box (no expansion):
+
+```jldoctest
 lon = [-78.6, -80.8, -82.5]
 lat = [35.8, 35.2, 35.6]
+mapbbox(lon, lat)
 
-# Tight bounding box (no expansion)
-(xlim, ylim) = mapbbox(lon, lat)
+# output
 
-# Expand 10% on each side for map padding
-(xlim, ylim) = mapbbox(lon, lat; xexpand=0.1, yexpand=0.1)
+((-82.5, -78.6), (35.2, 35.8))
+```
+
+Expanded 10% on each side for map padding:
+
+```jldoctest
+lon = [-78.6, -80.8, -82.5]
+lat = [35.8, 35.2, 35.6]
+mapbbox(lon, lat; xexpand=0.1, yexpand=0.1)
+
+# output
+
+((-82.89, -78.21), (35.14, 35.86))
 ```
 """
 function mapbbox(x::Union{AbstractVector{<:Real}, Tuple{Vararg{Real}}},

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using Test
 using CairoMakie
 using GeoMakie
 
+include("test_doctests.jl")
 include("test_loctools.jl")
 include("test_disttools.jl")
 include("test_transtools.jl")

--- a/test/test_doctests.jl
+++ b/test/test_doctests.jl
@@ -1,0 +1,11 @@
+using Documenter
+
+# Run the docstring `jldoctest` blocks and verify their `# output` against live behavior
+# on every PR. The dedicated `docs` CI job only runs on release tags, so without this the
+# examples could silently drift between releases. `manual=false` restricts the run to
+# docstrings (no `docs/src` manual pages needed here). See CONTRIBUTING for the
+# examples-must-show-output convention.
+@testset "doctests" begin
+    DocMeta.setdocmeta!(Logjam, :DocTestSetup, :(using Logjam); recursive=true)
+    doctest(Logjam; manual=false)
+end


### PR DESCRIPTION
## Summary

Establishes a **docstring-examples-must-show-output** convention across the Location-bundle modules, so every example either self-verifies in CI or carries a captured-output comment. Doc/test-only — **no behavior or API change**.

Two tiers, by determinism:

- **Deterministic/pure → `jldoctest` `# output`** (CI-enforced, 22 functions): the UFL family (`ufladd`, `ufldrop`, `uflxchg`, `ufl`, `pmedian`), distances (`dgc`, `d1`, `d2`, `dists`, `dgca`), data helpers (`st2fips`, `fips2st`, `snapvals`, `isptinbbox`, `alloclines`, `prt`), `wcentroid`, and the map constants/helpers (`WORLD_LIMITS`, `US_LIMITS`, `CUS_LIMITS`, `mapbbox`, `aligntext`).
- **Fragile tier → runnable `julia` + captured-output comments** (can't be CI doctests): RNG (`randX`, `ala`), network geocoding (`loc2lonlat`, `lonlat2loc`), bulk-data loaders (census/CBSA/CSA + FAF5), and figure functions (`makemap`, `plotroads!`, `plotroute!`).

## Why

An example without its output only shows *how to call*, not *what's correct*. Showing the return makes each docstring an oracle for unit-testing and a regression tripwire.

## CI wiring

Doctests previously ran only on release tags (the `docs` job). This adds `test/test_doctests.jl` (running `doctest(Logjam; manual=false)`) to the suite and `Documenter` to the test target, so **doctests now gate every PR**.

## Robustness

- Trig-based results (`dgc`, `dgca`, geographic `dists`, `wcentroid`) are shown **rounded** so Windows-captured output matches Linux CI (last-ULP libm differences); algebraic and discrete outputs are shown verbatim.
- The one residual: array-display doctests could in principle shift format on Julia `pre`.

## Adopting the canonical example

The UFL family now shares one **sourced** example — Example 8.8 in Francis, *Facility Layout and Location* (2nd ed.; Daskin Figs. 7.2/7.3/7.5) — replacing prior unsourced ad-hoc matrices, and it demonstrates the heuristics meaningfully (ADD/DROP reach TC 32, EXCHANGE improves to 31, the hybrid confirms 31).

## Incidental fixes surfaced by the convention

- `prt`: the example's spacing no longer matched actual output.
- `US_LIMITS`: described as the *contiguous* U.S., but its `(-180, -65)` range covers Alaska/Hawaii (`CUS_LIMITS` is the contiguous box).

## Verification

`Pkg.test()` green locally, including the new `doctests` testset (`Documenter v1.17.0` resolved in the test sandbox).

## Scope

Not touched: `transtools`, `roadtools`, `routetools`, `osmtools` — not in the interface-review bundle yet; they fold in when their review rounds come up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F7KD2dcrUUYVXyKRAjiwm7
