### PR TITLE
loctools v0.2.9: NF/EF terminology + ala simplification

### DIFF
--- a/src/loctools.jl
+++ b/src/loctools.jl
@@ -382,32 +382,20 @@ function _aladist(x, y, dist)
     end
 end
 
-# Default allocate: assign each demand point to its nearest new facility, build a
-# sparse n×m weight matrix, and relocate any orphaned (all-zero-row) facility to a
-# random demand point until every facility is used (mirrors ala.m `default_alloc`).
+# Default allocate: assign each EF to its nearest NF and build the sparse n×m weight matrix.
+# An NF allocated no EFs simply gets a zero row (left unused); such a run returns a higher
+# `TC` and is discarded by the multi-run (`nruns`) minimum in `ala`. Deterministic (no RNG).
 function _ala_alloc(X, w, P, dist)
     m = length(w)
-    Xw = copy(X)
     wf = Float64.(collect(w))
-    local W, D
-    done = false
-    while !done
-        D = dists(Xw, P, dist)                       # n×m distance matrix
-        assign = [argmin(@view D[:, j]) for j in 1:m]
-        W = sparse(assign, 1:m, wf, size(Xw, 1), m)
-        idx0 = findall(iszero, vec(sum(W, dims=2)))  # unallocated facilities
-        if isempty(idx0)
-            done = true
-        else                                          # relocate orphans to random EFs
-            perm = sortperm(rand(size(P, 1)))
-            Xw[idx0, :] = P[perm[1:length(idx0)], :]
-        end
-    end
+    D = dists(X, P, dist)                        # n×m distance matrix (NF × EF)
+    assign = [argmin(@view D[:, j]) for j in 1:m]
+    W = sparse(assign, 1:m, wf, size(X, 1), m)
     return W, sum(W .* D)
 end
 
-# Default locate: per-facility continuous minisum. For each facility, minimise the
-# weighted sum of distances to its allocated demand points via `Optim.optimize`.
+# Default locate: per-NF continuous minisum. For each NF, minimise the weighted sum of
+# distances to its allocated EFs via `Optim.optimize`.
 function _ala_locate(W, X, dist, P)
     Xnew = copy(X)
     for i in axes(W, 1)
@@ -438,21 +426,20 @@ function _ala_run(X, alloc_fn, locate_fn)
 end
 
 """
-    ala(X0, w, P; dist=:mi, alloc=<default>, locate=<default>, nruns=1) -> (X, TC, W)
+    ala(X0, w, P; dist=:mi, alloc=<default>, locate=<default>, nruns=1, verbose=true) -> (X, TC, W)
 
-Alternating location–allocation for locating `n` new facilities among `m` weighted
-demand points.
+Alternating location–allocation: locate `n` new facilities (NFs) to serve `m` weighted
+existing facilities (EFs).
 
-Starting from `n` facility locations `X0`, alternate two steps until the total cost
-`TC` stops decreasing: **allocate** each demand point to its nearest facility, then
-**locate** each facility at the continuous minisum of its allocated points. The default
-allocate step relocates any orphaned (unused) facility to a random demand point so no
-zero-weight facility persists.
+Starting from `n` NF locations `X0`, alternate two steps until the total cost `TC` stops
+decreasing: **allocate** each EF to its nearest NF, then **locate** each NF at the continuous
+minisum of its allocated EFs. A run may leave an NF unused (allocated no EFs); that run
+returns a higher `TC` and is discarded when `nruns > 1`, so take several runs.
 
 # Formulation
-Given demand points ``P = \\{P_j\\}_{j=1}^m``, weights ``w_j \\ge 0``, and ``n`` new
-facilities, choose facility locations ``X = \\{X_i\\}_{i=1}^n \\subset \\mathbb{R}^2``
-and allocation ``W \\in \\{0,1\\}^{n \\times m}`` to minimise
+Given EFs ``P = \\{P_j\\}_{j=1}^m``, weights ``w_j \\ge 0``, and ``n`` NFs, choose NF
+locations ``X = \\{X_i\\}_{i=1}^n \\subset \\mathbb{R}^2`` and allocation
+``W \\in \\{0,1\\}^{n \\times m}`` to minimise
 
 ```math
 \\min_{X,\\,W}\\; TC = \\sum_{j=1}^{m} w_j\\, d\\!\\left(X_{\\sigma(j)}, P_j\\right),
@@ -461,54 +448,53 @@ and allocation ``W \\in \\{0,1\\}^{n \\times m}`` to minimise
 
 alternating
 
-- **allocate:** ``\\sigma(j) = \\arg\\min_i d(X_i, P_j)`` (nearest facility);
+- **allocate:** ``\\sigma(j) = \\arg\\min_i d(X_i, P_j)`` (nearest NF);
 - **locate:** ``X_i \\leftarrow \\arg\\min_{X} \\sum_{j:\\sigma(j)=i} w_j\\, d(X, P_j)``
-  (per-facility minisum),
+  (per-NF minisum),
 
-iterating until ``TC`` is non-decreasing.
-
-**Orphan rule:** if ``\\{j : \\sigma(j) = i\\} = \\varnothing`` for some ``i``, relocate
-``X_i`` to a random ``P_j`` and re-allocate; loop until every facility is used. The
-distance ``d`` defaults to the great-circle distance ``d_{gc}`` (`dist=:mi`). With
-`nruns` random starts, the minimum-`TC` solution is returned.
+iterating until ``TC`` is non-decreasing. The distance ``d`` defaults to the great-circle
+distance ``d_{gc}`` (`dist=:mi`). With `nruns` random starts, the minimum-`TC` result is
+returned.
 
 # Arguments
-- `X0`: n×2 matrix of initial facility locations (LON, LAT).
-- `w`: length-m vector of demand weights (`w_j ≥ 0`).
-- `P`: m×2 matrix of demand-point locations (LON, LAT).
+- `X0`: n×2 matrix of initial NF locations (LON, LAT).
+- `w`: length-m weight vector (`w_j ≥ 0`).
+- `P`: m×2 matrix of EF locations (LON, LAT).
 - `dist`: distance metric — `:mi` (default), `:km`, `:rad` (great-circle), or `1`/`2`
   (rectilinear/Euclidean).
-- `alloc`: allocate handle `X -> (W, TC)` overriding the default nearest-facility
-  allocation (e.g. for forced/constrained partitions).
-- `locate`: locate handle `(W, X) -> X` overriding the default per-facility minisum.
-- `nruns`: number of independent random restarts. Run 1 uses `X0`; runs 2…`nruns` use
-  fresh `randX(P, n)` starts. The best (minimum-`TC`) result is returned.
+- `alloc`: allocate handle `X -> (W, TC)` overriding the default nearest-NF allocation
+  (e.g. for forced/constrained partitions).
+- `locate`: locate handle `(W, X) -> X` overriding the default per-NF minisum.
+- `nruns`: number of independent restarts. Run 1 uses `X0`; runs 2…`nruns` use fresh
+  `randX(P, n)` starts. The best (minimum-`TC`) result is returned. Take several runs — a
+  single run can leave an NF unused.
+- `verbose`: print each run's `TC` (default: `true`).
 
 # Returns
-- `(X, TC, W)`: n×2 facility locations, total cost `TC`, and the n×m sparse allocation
-  matrix `W` where `W[i,j]` is the weight facility `i` serves from demand point `j`.
+- `(X, TC, W)`: n×2 NF locations, total cost `TC`, and the n×m sparse allocation matrix `W`
+  where `W[i,j]` is the weight NF `i` serves from EF `j`.
 
 # Example
-Locate two facilities to serve four North Carolina cities. The `locate` step calls a
-continuous optimizer and the orphan rule draws from the RNG, so `TC` is shown rounded and
-may vary slightly across Optim/Julia versions.
+Locate two NFs to serve four North Carolina cities. `verbose` prints each run; over several
+runs the best `TC` is stable at `34194.6` (great-circle miles), though per-run values and the
+last digits vary with the random restarts.
 
 ```julia
 P  = [-78.64 35.78; -80.84 35.23; -79.79 36.07; -77.94 34.23]  # Raleigh, Charlotte, Greensboro, Wilmington
 w  = [469.0, 897.0, 299.0, 123.0]
 X0 = [-78.6 35.8; -80.0 35.5]
-X, TC, W = ala(X0, w, P)          # dist=:mi great-circle minisum
-round(TC; digits=1)               # => 34194.6 (great-circle miles)
+X, TC, W = ala(X0, w, P; nruns=5)   # dist=:mi great-circle minisum; prints Run 1..5
+round(TC; digits=1)                 # => 34194.6
 ```
 
 # References
 - M.G. Kay, *Facility Location* (course notes), NC State University; Matlog `ala`.
 """
-function ala(X0, w, P; dist=:mi, alloc=nothing, locate=nothing, nruns::Int=1)
+function ala(X0, w, P; dist=:mi, alloc=nothing, locate=nothing, nruns::Int=1, verbose::Bool=true)
     size(X0, 2) == size(P, 2) || error("ala: X0 and P must have the same number of columns.")
     length(w) == size(P, 1) || error("ala: length(w) must equal the number of rows in P.")
     n = size(X0, 1)
-    n <= size(P, 1) || error("ala: number of facilities (n=$n) cannot exceed number of demand points (m=$(size(P, 1))).")
+    n <= size(P, 1) || error("ala: number of NFs (n=$n) cannot exceed number of EFs (m=$(size(P, 1))).")
     nruns >= 1 || error("ala: nruns must be ≥ 1.")
 
     alloc_fn = alloc === nothing ? (X -> _ala_alloc(X, w, P, dist)) : alloc
@@ -519,10 +505,12 @@ function ala(X0, w, P; dist=:mi, alloc=nothing, locate=nothing, nruns::Int=1)
     for run in 1:nruns
         Xstart = run == 1 ? Matrix{Float64}(X0) : Matrix{Float64}(randX(P, n))
         X, TC, W = _ala_run(Xstart, alloc_fn, locate_fn)
+        verbose && println("  Run ", run, ": TC = ", round(TC; digits=1))
         if TC < bestTC
             bestTC, bestX, bestW = TC, X, W
         end
     end
+    verbose && nruns > 1 && println("  Best:   TC = ", round(bestTC; digits=1))
     return bestX, bestTC, bestW
 end
 

--- a/src/loctools.jl
+++ b/src/loctools.jl
@@ -15,21 +15,21 @@ end
 
 Greedy ADD construction heuristic for uncapacitated facility location.
 
-Iteratively opens the facility giving the greatest cost reduction until no improvement
-is possible (or `p` facilities are open).
+Iteratively opens the new facility (NF) giving the greatest cost reduction until no
+improvement is possible (or `p` NFs are open).
 
 # Arguments
-- `k`: Fixed cost. Scalar (same cost at every site) or length-`n` vector, `k[i]` = cost
-  of opening a facility at candidate site `i`.
-- `C`: `n`×`m` variable-cost matrix over `n` candidate sites and `m` customers; `C[i,j]`
-  = cost of serving customer `j` from site `i`.
-- `y`: initial set of open sites (default: empty — start from scratch).
-- `p`: cap on the number of open facilities (default: `nothing`, no cap).
+- `k`: Fixed cost. Scalar (same cost at every NF site) or length-`n` vector, `k[i]` = cost
+  of opening an NF at candidate site `i`.
+- `C`: `n`×`m` variable-cost matrix over `n` candidate NF sites and `m` existing facilities
+  (EFs); `C[i,j]` = cost of serving EF `j` from an NF at site `i`.
+- `y`: indices of the initially-open NF sites (default: empty — start from scratch).
+- `p`: cap on the number of open NFs (default: `nothing`, no cap).
 
 # Returns
-- `(y, TC, W)`: open-facility site indices; total cost `TC = sum(k[y]) + sum(C[allocated])`;
-  and the `n`×`m` sparse allocation matrix `W`, `W[i,j] = 1` if customer `j` is served by
-  facility `i`.
+- `(y, TC, W)`: indices of the open NF sites; total cost `TC = sum(k[y]) + sum(C[allocated])`;
+  and the `n`×`m` sparse allocation matrix `W`, `W[i,j] = 1` if EF `j` is served by the NF
+  at site `i`.
 
 # Example
 Example 8.8 in Francis, *Facility Layout and Location*, 2nd ed. (Daskin, *Network and
@@ -86,21 +86,21 @@ end
 
 Greedy DROP construction heuristic for uncapacitated facility location.
 
-Starts with every facility open and iteratively closes the one giving the greatest cost
-reduction until no improvement is possible (or `p` remain).
+Starts with every new facility (NF) open and iteratively closes the one giving the greatest
+cost reduction until no improvement is possible (or `p` NFs remain).
 
 # Arguments
-- `k`: Fixed cost. Scalar (same cost at every site) or length-`n` vector, `k[i]` = cost
-  of opening a facility at candidate site `i`.
-- `C`: `n`×`m` variable-cost matrix over `n` candidate sites and `m` customers; `C[i,j]`
-  = cost of serving customer `j` from site `i`.
-- `y`: initial set of open sites (default: all sites open).
-- `p`: target number of open facilities (default: `nothing`, drop until no improvement).
+- `k`: Fixed cost. Scalar (same cost at every NF site) or length-`n` vector, `k[i]` = cost
+  of opening an NF at candidate site `i`.
+- `C`: `n`×`m` variable-cost matrix over `n` candidate NF sites and `m` existing facilities
+  (EFs); `C[i,j]` = cost of serving EF `j` from an NF at site `i`.
+- `y`: indices of the initially-open NF sites (default: all NF sites open).
+- `p`: target number of open NFs (default: `nothing`, drop until no improvement).
 
 # Returns
-- `(y, TC, W)`: open-facility site indices; total cost `TC = sum(k[y]) + sum(C[allocated])`;
-  and the `n`×`m` sparse allocation matrix `W`, `W[i,j] = 1` if customer `j` is served by
-  facility `i`.
+- `(y, TC, W)`: indices of the open NF sites; total cost `TC = sum(k[y]) + sum(C[allocated])`;
+  and the `n`×`m` sparse allocation matrix `W`, `W[i,j] = 1` if EF `j` is served by the NF
+  at site `i`.
 
 # Example
 Example 8.8 in Francis, *Facility Layout and Location*, 2nd ed. (Daskin, *Network and
@@ -159,20 +159,20 @@ end
 
 Pairwise EXCHANGE improvement heuristic for uncapacitated facility location.
 
-Steepest-descent swaps (close one open facility, open one closed) from a starting set `y`
-until a local optimum is reached. The swap preserves the number of open facilities, so
+Steepest-descent swaps — close one open new facility (NF), open one closed — from a starting
+set `y` until a local optimum is reached. The swap preserves the number of open NFs, so
 `y` sets the cardinality.
 
 # Arguments
-- `k`: Fixed cost. Scalar (same cost at every site) or length-`n` vector (see [`ufladd`](@ref)).
-- `C`: `n`×`m` variable-cost matrix over `n` candidate sites and `m` customers; `C[i,j]`
-  = cost of serving customer `j` from site `i`.
-- `y`: starting set of open sites (required — exchange improves *this* set).
+- `k`: Fixed cost. Scalar (same cost at every NF site) or length-`n` vector (see [`ufladd`](@ref)).
+- `C`: `n`×`m` variable-cost matrix over `n` candidate NF sites and `m` existing facilities
+  (EFs); `C[i,j]` = cost of serving EF `j` from an NF at site `i`.
+- `y`: indices of the starting open NF sites (required — exchange improves *this* set).
 
 # Returns
-- `(y, TC, W)`: improved open-facility site indices; total cost
+- `(y, TC, W)`: indices of the improved open NF sites; total cost
   `TC = sum(k[y]) + sum(C[allocated])`; and the `n`×`m` sparse allocation matrix `W`,
-  `W[i,j] = 1` if customer `j` is served by facility `i`.
+  `W[i,j] = 1` if EF `j` is served by the NF at site `i`.
 
 # Example
 Improve the ADD solution to Example 8.8 (Francis, 2nd ed.; Daskin, Fig. 7.5): the swap
@@ -253,15 +253,15 @@ a better solution than any single procedure alone. With the default `verbose=tru
 the per-step `Add`/`Xchg`/`Drop` cost trace.
 
 # Arguments
-- `k`: Fixed cost. Scalar (same cost at every site) or length-`n` vector (see [`ufladd`](@ref)).
-- `C`: `n`×`m` variable-cost matrix over `n` candidate sites and `m` customers; `C[i,j]`
-  = cost of serving customer `j` from site `i`.
+- `k`: Fixed cost. Scalar (same cost at every NF site) or length-`n` vector (see [`ufladd`](@ref)).
+- `C`: `n`×`m` variable-cost matrix over `n` candidate new-facility (NF) sites and `m`
+  existing facilities (EFs); `C[i,j]` = cost of serving EF `j` from an NF at site `i`.
 - `verbose`: print the per-step cost trace (default: `true`).
 
 # Returns
-- `(y, TC, W)`: best open-facility site indices found; total cost
+- `(y, TC, W)`: indices of the best open NF sites found; total cost
   `TC = sum(k[y]) + sum(C[allocated])`; and the `n`×`m` sparse allocation matrix `W`,
-  `W[i,j] = 1` if customer `j` is served by facility `i`.
+  `W[i,j] = 1` if EF `j` is served by the NF at site `i`.
 
 # Example
 Example 8.8 in Francis, *Facility Layout and Location*, 2nd ed. The hybrid improves on ADD
@@ -275,11 +275,15 @@ C = [ 0  3  7 10  6  4
      10  7  3  0  7  8
       6  6  6  7  0  2
       4  7  8  8  2  0]
-y, TC, W = ufl(k, C; verbose=false)
+y, TC, W = ufl(k, C)
 (y, TC)
 
 # output
 
+  Add: 32.0
+ Xchg: 31.0
+  Add: 31.0
+ Drop: 31.0
 ([3, 6], 31.0)
 ```
 
@@ -317,20 +321,20 @@ end
 """
     pmedian(p, C; verbose=true) -> (Vector{Int}, Float64, SparseMatrixCSC)
 
-p-median facility location: open exactly `p` facilities (no fixed costs) to minimize total
-assignment cost. Uses [`ufladd`](@ref) with `k=0` to select `p`, then [`uflxchg`](@ref) to
-improve.
+p-median facility location: open exactly `p` new facilities (NFs; no fixed costs) to minimize
+total assignment cost. Uses [`ufladd`](@ref) with `k=0` to select `p`, then [`uflxchg`](@ref)
+to improve.
 
 # Arguments
-- `p`: number of facilities to open.
-- `C`: `n`×`m` variable-cost matrix over `n` candidate sites and `m` customers; `C[i,j]`
-  = cost of serving customer `j` from site `i`.
+- `p`: number of NFs to open.
+- `C`: `n`×`m` variable-cost matrix over `n` candidate NF sites and `m` existing facilities
+  (EFs); `C[i,j]` = cost of serving EF `j` from an NF at site `i`.
 - `verbose`: print the selection trace (default: `true`).
 
 # Returns
-- `(y, TC, W)`: the `p` open-facility site indices; total cost `TC = sum(C[allocated])`
+- `(y, TC, W)`: indices of the `p` open NF sites; total cost `TC = sum(C[allocated])`
   (transport only, no fixed costs); and the `n`×`m` sparse allocation matrix `W`,
-  `W[i,j] = 1` if customer `j` is served by facility `i`.
+  `W[i,j] = 1` if EF `j` is served by the NF at site `i`.
 
 # Example
 Same cost matrix as Example 8.8 (Francis, 2nd ed.), with fixed costs dropped.

--- a/test/test_loctools.jl
+++ b/test/test_loctools.jl
@@ -251,15 +251,15 @@ using DataFrames
         P = [0.0 0.0; 1.0 0.0; 0.0 1.0; 1.0 1.0]
         w = [1.0, 1.0, 1.0, 1.0]
 
-        @testset "N1: orphan relocation" begin
-            Random.seed!(20270705)
-            # Facility 3 starts far away and would never be nearest → orphaned.
+        @testset "N1: an unused NF is left as a zero row (no relocation)" begin
+            # NF 3 starts far away and is never nearest → allocated no EFs (a zero row).
             X0 = [0.2 0.2; 0.8 0.8; 100.0 100.0]
-            X, TC, W = ala(X0, w, P; dist=2)
-            @test size(X, 1) == 3                      # all facilities retained
+            X, TC, W = ala(X0, w, P; dist=2, verbose=false)
+            @test size(X, 1) == 3                          # all NF rows retained (unused NF left in place)
             @test size(W) == (3, 4)
-            @test !any(vec(sum(W, dims=2)) .== 0)      # no all-zero (orphaned) row
-            @test all(sum(W, dims=1) .≈ 1.0)           # every demand point allocated once
+            @test count(vec(sum(W, dims=2)) .== 0) == 1    # exactly one NF unused
+            @test sum(W[3, :]) == 0                        # it is NF 3 (the far one)
+            @test all(sum(W, dims=1) .≈ 1.0)               # every EF still allocated once
             @test TC < Inf
         end
 
@@ -270,7 +270,7 @@ using DataFrames
             # Custom locate always parks every facility at the origin.
             mylocate = (W, X) -> zeros(size(X))
             X0 = [50.0 50.0; -50.0 -50.0]
-            X, TC, W = ala(X0, w, P; dist=2, alloc=myalloc, locate=mylocate)
+            X, TC, W = ala(X0, w, P; dist=2, alloc=myalloc, locate=mylocate, verbose=false)
             @test W == Wfixed                          # custom allocation honored
             @test all(X .== 0.0)                        # custom locate honored
         end
@@ -278,9 +278,9 @@ using DataFrames
         @testset "N3: nruns returns best-of" begin
             X0 = [0.9 0.1; 0.1 0.9]
             Random.seed!(4242)
-            _, TC1, _ = ala(X0, w, P; dist=2, nruns=1)
+            _, TC1, _ = ala(X0, w, P; dist=2, nruns=1, verbose=false)
             Random.seed!(4242)
-            _, TC5, _ = ala(X0, w, P; dist=2, nruns=5)
+            _, TC5, _ = ala(X0, w, P; dist=2, nruns=5, verbose=false)
             # Run 1 is identical (same seed, same X0), extra runs can only improve.
             @test TC5 <= TC1 + 1e-9
         end
@@ -291,7 +291,7 @@ using DataFrames
             Pnc = [-78.64 35.78; -80.84 35.23; -79.79 36.07; -77.94 34.23]
             wnc = [469.0, 897.0, 299.0, 123.0]
             X0 = [-78.6 35.8; -80.0 35.5]
-            X, TC, W = ala(X0, wnc, Pnc)               # dist=:mi default
+            X, TC, W = ala(X0, wnc, Pnc; verbose=false)  # dist=:mi default
             @test size(X) == (2, 2)
             @test size(W) == (2, 4)
             @test issparse(W)


### PR DESCRIPTION
## Summary

Two loctools improvements for v0.2.9, doc-heavy with one small algorithm change.

### 1. NF/EF terminology (doc-only)
Standardizes the facility-location docstrings on the Matlog/Francis **NF** (new facility) / **EF** (existing facility) vocabulary across `ufladd`, `ufldrop`, `uflxchg`, `ufl`, `pmedian`, and `ala`, each defined once parenthetically. `EF` is the neutral structural term — "customer"/"demand" removed (demand is only one application of an EF). `y` is described as site *indices* on both input and output; `n`/`m` are pinned to the axes. `ufl`'s example now uses the default `verbose=true` so the `Add/Xchg/Drop` trace shows in its jldoctest output.

### 2. `ala` simplification (code + docs)
- **Drops the random orphan-relocation** from the default allocate step: an NF allocated no EFs is simply left unused (a zero row), which yields a higher `TC` and is discarded by the `nruns` minimum. This makes the allocate step deterministic (only `randX` restarts use RNG) and removes the cryptic orphan-rule from the docstring.
- **Adds a `verbose` kwarg** (default `true`, matching `ufl`/`pmedian`) that prints each run's rounded `TC` and, for `nruns>1`, the best — Matlog's per-run display, built in.
- The example is now **self-reinforcing**: every run of the NC-cities case lands on `TC 34194.6`, so a student can reproduce it. Default `nruns` stays `1`.

## Tests
`N1` rewritten to assert the new unused-NF-zero-row behavior; **all 121 loctools tests pass**, doctests green.

## Notes
Builds on `1696cb5` (the ISCUS/​`v0.2.9` version bump already on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F7KD2dcrUUYVXyKRAjiwm7
